### PR TITLE
Fix CSRF instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ React.createElement(GraphiQL, {
         url: '{{ url(config('graphiql.endpoint')) }}',
         subscriptionUrl: '{{ config('graphiql.subscription-endpoint') }}',
     }),
++   shouldPersistHeaders: true,
 +   headers: JSON.stringify({
 +       'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
 +   }),

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ React.createElement(GraphiQL, {
     fetcher: GraphiQL.createFetcher({
         url: '{{ url(config('graphiql.endpoint')) }}',
         subscriptionUrl: '{{ config('graphiql.subscription-endpoint') }}',
-+       headers: {
-+           'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-+       },
     }),
++   headers: JSON.stringify({
++       'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
++   }),
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ React.createElement(GraphiQL, {
     fetcher: GraphiQL.createFetcher({
         url: '{{ url(config('graphiql.endpoint')) }}',
         subscriptionUrl: '{{ config('graphiql.subscription-endpoint') }}',
++       headers: {
++           'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
++       },
     }),
-+   headers: {
-+       'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-+   },
 })
 ```
 


### PR DESCRIPTION
`headers` is an option of `GraphiQL.createFetcher` and not of `React.createElement`