### PR TITLE
Use url or path

### DIFF
--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -31,7 +31,7 @@
 <script src="{{ \MLL\GraphiQL\DownloadAssetsCommand::explorerPluginPath() }}"></script>
 <script>
     const fetcher = GraphiQL.createFetcher({
-        url: '{{ url(config('graphiql.endpoint')) }}',
+        url: '{{ filter_var($endpoint = config('graphiql.endpoint'), FILTER_VALIDATE_URL) ? url($endpoint) : $endpoint }}',
         subscriptionUrl: '{{ config('graphiql.subscription-endpoint') }}',
     });
 


### PR DESCRIPTION
I think this would make it work to any URL and with path. Also would avoid the issue where it would pass 'http' instead of 'https'