### PR TITLE
Added custom styles for GraphiQL Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ See [GitHub releases](https://github.com/mll-lab/laravel-graphiql/releases).
 
 ## Unreleased
 
-Fixed an issue where scrolling would become impossible if content was larger than the screens height.
-Adjusted the styling of the eplorer tabs title.
-Added some margin to the select element within the explorers actions
+### Fixed
+
+- Allow scrolling in GraphiQL explorer plugin
+
+### Changed
+
+- Adjusted styling of the GraphiQL eplorer tab title
+- Added some margin to the select element within the GraphiQL explorer actions
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [GitHub releases](https://github.com/mll-lab/laravel-graphiql/releases).
 
 ## Unreleased
 
+Fixed an issue where scrolling would become impossible if content was larger than the screens height.
+Adjusted the styling of the eplorer tabs title.
+Added some margin to the select element within the explorers actions
+
 ## v2.0.0
 
 ### Added

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -24,7 +24,6 @@
             width: 100% !important;
             height: auto !important;
         }
-
         .doc-explorer-title-bar {
             font-weight: var(--font-weight-medium);
             font-size: var(--font-size-h2);
@@ -32,15 +31,12 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-
         .doc-explorer-rhs {
             display: none;
         }
-
         .doc-explorer-contents {
             margin: var(--px-16) 0 0;
         }
-
         .graphiql-explorer-actions select {
             margin-left: var(--px-12);
         }

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -17,6 +17,33 @@
         #graphiql {
             height: 100vh;
         }
+
+        /* Make the explorer feel more integrated */
+        .docExplorerWrap {
+            overflow: auto !important;
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        .doc-explorer-title-bar {
+            font-weight: var(--font-weight-medium);
+            font-size: var(--font-size-h2);
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .doc-explorer-rhs {
+            display: none;
+        }
+
+        .doc-explorer-contents {
+            margin: var(--px-16) 0 0;
+        }
+
+        .graphiql-explorer-actions select {
+            margin-left: var(--px-12);
+        }
     </style>
     <script src="{{ \MLL\GraphiQL\DownloadAssetsCommand::reactPath() }}"></script>
     <script src="{{ \MLL\GraphiQL\DownloadAssetsCommand::reactDOMPath() }}"></script>


### PR DESCRIPTION
# Summary

Added some custom styles for the explorer.

Increased margin for the explorers select action element
Adjusted style for the explorers tab title to look like the other tab titles
Removed `X` from the explores title

## Notes
The !important for the class `.docExplorerWrap` are needed if the style is supposed to stay in there with the other custom styles.

Updated style is seen below.
<img width="472" alt="image" src="https://user-images.githubusercontent.com/69695342/232427180-260590cf-bb53-46b0-b6a9-62945f42a6ba.png">
