### PR TITLE
Support Laravel 12

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,12 +35,18 @@ jobs:
             laravel-version: "^10"
           - php-version: "8.0"
             laravel-version: "^11"
-          - php-version: "8.1"
-            laravel-version: "^11"
           - php-version: "8.0"
             laravel-version: "^12"
           - php-version: "8.1"
+            laravel-version: "^11"
+          - php-version: "8.1"
             laravel-version: "^12"
+          - php-version: "8.3"
+            laravel-version: "^9"
+          - php-version: "8.4"
+            laravel-version: "^9"
+          - php-version: "8.4"
+            laravel-version: "^10"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,10 +18,13 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         laravel-version:
           - "^9"
           - "^10"
           - "^11"
+          - "^12"
         composer:
           - name: lowest
             arg: "--prefer-lowest --prefer-stable"
@@ -34,6 +37,10 @@ jobs:
             laravel-version: "^11"
           - php-version: "8.1"
             laravel-version: "^11"
+          - php-version: "8.0"
+            laravel-version: "^12"
+          - php-version: "8.1"
+            laravel-version: "^12"
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -15,19 +15,17 @@
   ],
   "require": {
     "php": "^8",
-    "illuminate/console": "^9 || ^10 || ^11",
-    "illuminate/contracts": "^9 || ^10 || ^11",
-    "illuminate/support": "^9 || ^10 || ^11"
+    "illuminate/console": "^9 || ^10 || ^11 || ^12",
+    "illuminate/contracts": "^9 || ^10 || ^11 || ^12",
+    "illuminate/support": "^9 || ^10 || ^11 || ^12"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.29",
-    "larastan/larastan": "^2.5.2",
+    "larastan/larastan": "^2.5.2 || ^3",
     "mll-lab/php-cs-fixer-config": "^5",
-    "orchestra/testbench": "^7.7 || ^8.8 || ^9",
+    "orchestra/testbench": "^7.7 || ^8.8 || ^9 || ^10",
     "phpstan/extension-installer": "^1",
-    "phpstan/phpstan": "^1.10.15",
-    "phpstan/phpstan-mockery": "^1.1.1",
-    "phpstan/phpstan-phpunit": "^1.3.11"
+    "phpstan/phpstan": "^1.10.15 || ^2"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
## Summary
- This is currently blocked because larastan has no L12 compatible release. I'm not sure we'll get one for larastan 2 or require larastan 3 or if larastan 3 will work (which would require phpstan 2)
  So we need to wait and see until either
  - [ ] ~https://github.com/larastan/larastan/pull/2198~
    or
  - [x] https://github.com/larastan/larastan/pull/2195
    is merged
- I removed `phpstan/phpstan-mockery` and `phpstan/phpstan-phpunit`, they don't seem to be used
- [ ] There seem to be also new phpstan errors to appear -> but I figure it's also best to wait and see first how larastan compatibility resolves